### PR TITLE
avoid stackoverflow, when accessing entities with lazy loaded references via JSON-Request

### DIFF
--- a/user/src/main/java/org/dicadeveloper/weplantaforest/ViewSessionFilter.java
+++ b/user/src/main/java/org/dicadeveloper/weplantaforest/ViewSessionFilter.java
@@ -1,0 +1,9 @@
+package org.dicadeveloper.weplantaforest;
+
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ViewSessionFilter extends OpenEntityManagerInViewFilter{
+
+}

--- a/user/src/main/java/org/dicadeveloper/weplantaforest/Views.java
+++ b/user/src/main/java/org/dicadeveloper/weplantaforest/Views.java
@@ -1,0 +1,6 @@
+package org.dicadeveloper.weplantaforest;
+
+public interface Views {
+    public static interface Public {}
+    public static interface Project extends Public{}
+}

--- a/user/src/main/java/org/dicadeveloper/weplantaforest/dev/inject/DatabasePopulator.java
+++ b/user/src/main/java/org/dicadeveloper/weplantaforest/dev/inject/DatabasePopulator.java
@@ -172,7 +172,7 @@ public class DatabasePopulator {
     public DatabasePopulator insertProjectArticles() {
         Random random = new Random();
 
-        for (Project project : _projectRepository.active(new PageRequest(0, 10))) {
+        for (Project project : _projectRepository.findAll()) {
             for (int i = 0; i < 3; i++) {
                 long randomAmount = random.nextInt(500);
 

--- a/user/src/main/java/org/dicadeveloper/weplantaforest/planting/PlantPageController.java
+++ b/user/src/main/java/org/dicadeveloper/weplantaforest/planting/PlantPageController.java
@@ -7,6 +7,7 @@ import org.dicadeveloper.weplantaforest.support.Uris;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +29,7 @@ public class PlantPageController {
 
     private @NonNull PlantPageDataValidator _plantPageDataValidator;
 
+    @Transactional
     @RequestMapping(value = Uris.COMPLEX_PROPOSAL_FOR_PRICE + "{targetedPrice}", method = RequestMethod.GET)
     public PlantPageData getCartProposal(@PathVariable long targetedPrice) {
         return plantPageDataHelper.createPlantProposalForTargetPrice(targetedPrice);

--- a/user/src/main/java/org/dicadeveloper/weplantaforest/planting/SimplePlantPageController.java
+++ b/user/src/main/java/org/dicadeveloper/weplantaforest/planting/SimplePlantPageController.java
@@ -7,6 +7,7 @@ import org.dicadeveloper.weplantaforest.support.Uris;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +29,7 @@ public class SimplePlantPageController {
 
     private @NonNull SimplePlantPageDataValidator _simplePlantPageDataValidator;
 
+    @Transactional
     @RequestMapping(value = Uris.SIMPLE_PROPOSAL_FOR_TREE + "{amountOfTrees}", method = RequestMethod.GET)
     public SimplePlantPageData getCartProposalForAmountOfTrees(@PathVariable long amountOfTrees) {
         return simplePlantPageDataHelper.createPlantProposalForAmountOfTrees(amountOfTrees);

--- a/user/src/main/java/org/dicadeveloper/weplantaforest/projects/Price.java
+++ b/user/src/main/java/org/dicadeveloper/weplantaforest/projects/Price.java
@@ -11,6 +11,10 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Transient;
 
+import org.dicadeveloper.weplantaforest.Views;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -37,6 +41,7 @@ public class Price {
     private ScontoType scontoType = ScontoType.NONE;
 
     @Column(name = "_amount", precision = 7, scale = 2)
+    @JsonView({Views.Project.class})
     private BigDecimal amount;
 
     @Column(name = "_funding", precision = 7, scale = 2)

--- a/user/src/main/java/org/dicadeveloper/weplantaforest/projects/Project.java
+++ b/user/src/main/java/org/dicadeveloper/weplantaforest/projects/Project.java
@@ -12,8 +12,11 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
+import org.dicadeveloper.weplantaforest.Views;
 import org.dicadeveloper.weplantaforest.trees.User;
 import org.springframework.hateoas.Identifiable;
+
+import com.fasterxml.jackson.annotation.JsonView;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -34,15 +37,19 @@ public class Project implements Identifiable<Long> {
     private Long id;
 
     @Column(name = "_name", length = 255)
+    @JsonView(Views.Project.class)
     private String name;
 
     @Column(name = "_description", length = 65535, columnDefinition = "TEXT")
+    @JsonView(Views.Project.class)
     private String description;
 
     @Column(name = "_longitude")
+    @JsonView({Views.Project.class})
     private Float longitude;
 
     @Column(name = "_latitude")
+    @JsonView(Views.Project.class)
     private Float latitude;
 
     @Column(name = "_zoom")
@@ -72,8 +79,10 @@ public class Project implements Identifiable<Long> {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "_manager__userId", nullable = false)
+    @JsonView(Views.Project.class)
     private User manager;
 
     @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
+    @JsonView(Views.Project.class)
     private List<ProjectArticle> articles;
 }

--- a/user/src/main/java/org/dicadeveloper/weplantaforest/projects/ProjectArticle.java
+++ b/user/src/main/java/org/dicadeveloper/weplantaforest/projects/ProjectArticle.java
@@ -13,8 +13,11 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
+import org.dicadeveloper.weplantaforest.Views;
 import org.dicadeveloper.weplantaforest.trees.Tree;
 import org.dicadeveloper.weplantaforest.treetypes.TreeType;
+
+import com.fasterxml.jackson.annotation.JsonView;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -32,6 +35,7 @@ public class ProjectArticle {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "_articleId")
+    @JsonView({Views.Project.class})
     private Long articleId;
 
     @OneToOne(fetch = FetchType.LAZY)
@@ -40,16 +44,19 @@ public class ProjectArticle {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "_treeType_treeTypeId", nullable = false)
+    @JsonView({Views.Project.class})
     private TreeType treeType;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "_price__priceId", nullable = false)
+    @JsonView({Views.Project.class})
     private Price price;
 
     @Column(name = "_description", length = 20000)
     private String description;
 
     @Column(name = "_amount")
+    @JsonView({Views.Project.class})
     private Long amount;
 
     @OneToMany(mappedBy = "projectArticle")

--- a/user/src/main/java/org/dicadeveloper/weplantaforest/projects/ProjectController.java
+++ b/user/src/main/java/org/dicadeveloper/weplantaforest/projects/ProjectController.java
@@ -1,0 +1,26 @@
+package org.dicadeveloper.weplantaforest.projects;
+
+import org.dicadeveloper.weplantaforest.Views;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class ProjectController {
+    
+    @Autowired
+    private @NonNull ProjectRepository _projectRepository;
+
+    @RequestMapping(value = "/projects", method = RequestMethod.GET)
+    @JsonView(Views.Project.class)
+    public Iterable<Project> list() {
+        return _projectRepository.findAll();
+    }
+}

--- a/user/src/main/java/org/dicadeveloper/weplantaforest/trees/User.java
+++ b/user/src/main/java/org/dicadeveloper/weplantaforest/trees/User.java
@@ -8,8 +8,11 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import org.dicadeveloper.weplantaforest.Views;
 import org.dicadeveloper.weplantaforest.admin.codes.Team;
 import org.springframework.hateoas.Identifiable;
+
+import com.fasterxml.jackson.annotation.JsonView;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -30,6 +33,7 @@ public class User implements Identifiable<Long> {
     private Long id;
 
     @Column(unique = true, name = "_name")
+    @JsonView({Views.Project.class})
     private String name;
 
     @Column(name = "_enabled", nullable = false)

--- a/user/src/main/java/org/dicadeveloper/weplantaforest/treetypes/TreeType.java
+++ b/user/src/main/java/org/dicadeveloper/weplantaforest/treetypes/TreeType.java
@@ -6,7 +6,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import org.dicadeveloper.weplantaforest.Views;
 import org.springframework.hateoas.Identifiable;
+
+import com.fasterxml.jackson.annotation.JsonView;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,6 +30,7 @@ public class TreeType implements Identifiable<Long> {
     private Long id;
 
     @Column(name = "_name", unique = true)
+    @JsonView({Views.Project.class})
     private String name;
 
     @Column(name = "_description")
@@ -39,6 +43,7 @@ public class TreeType implements Identifiable<Long> {
     private String infoLink;
 
     @Column(name = "_annualCo2SavingInTons")
+    @JsonView({Views.Project.class})
     private double annualCo2SavingInTons;
 
 }

--- a/user/src/test/java/org/dicadeveloper/weplantaforest/inject/DatabasePopulatorTest.java
+++ b/user/src/test/java/org/dicadeveloper/weplantaforest/inject/DatabasePopulatorTest.java
@@ -87,10 +87,7 @@ public class DatabasePopulatorTest {
         _databasePopulator.insertProjects();
         _databasePopulator.insertProjectArticles();
 
-        long activeProjectCount = _projectRepository.active(new PageRequest(0, 5))
-                                                    .getTotalElements();
-
-        assertThat(_projectArticleRepository.count()).isEqualTo(activeProjectCount * 3);
+        assertThat(_projectArticleRepository.count()).isEqualTo(30);
 
     }
 }


### PR DESCRIPTION
Here is a solution to avoid stackoverflow errors, when accessing entities with lazy loaded references via JSON-Request. 
I got this solution from this thread: http://stackoverflow.com/questions/30689697/jackson-hibernate-lots-of-problems

steps, which has to be done:
1. define a bean which extends **OpenEntityManagerInViewFilter**
2. define interfaces for the views, which should be shown in the frontend 
(as example i created a View for **Project**)
3. annotate the columns in the entity-objects, which should be shown by the defined interface
(**@JsonView(Views.Project.class)**)
4. create a Controller, which overrides the standard-CrudRepository method(**in this case findAll**) by mapping it to the same URL (**/projects**) and annotate it with **@JsonView(Views.Project.class)**

comment:
- the transaction-context of ProjectRepository changed by adding the OpenEntityManagerInViewFilter, so the PlantPageController methods had to be annotated with @Transactional to work correctly, else you get lazy loading exceptions, when trying to acces this lazy loaded objects(in this case getProjectArticles)

Please have a look at this and share your opinion